### PR TITLE
[fix] WIP - Support later versions of cel-rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,23 +583,24 @@ dependencies = [
 
 [[package]]
 name = "cel-interpreter"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9695f9bcc9ec195e0c35f2b9283adae5cef85cc41534a420216c8a12a323172"
+version = "0.8.1"
+source = "git+https://github.com/clarkmcc/cel-rust.git?branch=master#a5c6c2dbb658b13acf69f7b96c313288ae81d29b"
 dependencies = [
+ "base64 0.22.1",
  "cel-parser",
  "chrono",
  "nom",
  "paste",
+ "regex",
  "serde",
+ "serde_json",
  "thiserror",
 ]
 
 [[package]]
 name = "cel-parser"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a85ba148abbc551f1c32c8c0cff279dba234f6d38324bf372ba2395690879e"
+version = "0.7.1"
+source = "git+https://github.com/clarkmcc/cel-rust.git?branch=master#a5c6c2dbb658b13acf69f7b96c313288ae81d29b"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -635,9 +636,7 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "wasm-bindgen",
  "windows-targets",
 ]
 

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.83"
 aws-lc-rs = "1.8.1"
 base64 = "0.22.1"
 byteorder = "1.5.0"
-cel-interpreter = "0.7.1"
+cel-interpreter = { git = "https://github.com/clarkmcc/cel-rust.git", branch = "master", features = ["json"] }
 chrono = { version = "0.4.38", default-features = false, features = ["std", "clock"] }
 hex = "0.4.3"
 serde = { version = "1.0.209", features = ["derive"] }

--- a/enclave/src/expressions.rs
+++ b/enclave/src/expressions.rs
@@ -60,7 +60,8 @@ pub fn execute_expressions(
 
         context.add_variable_from_value(field, value.clone());
 
-        let result: Value = serde_json::to_value(value)
+        let result: Value = value
+            .json()
             .map_err(|err| anyhow!("Unable to serialize JSON value: {}", err))?;
         println!("[enclave] expression: {} = {:?}", expression, result);
 


### PR DESCRIPTION
*Issue #, if available:* fixes #8

*Description of changes:* Newer versions of `cel-interpreter` support a `.json()` method (https://github.com/clarkmcc/cel-rust/pull/77) to convert a CEL `Value` into a `serde_json::Value`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
