### PR TITLE
[feat] Store measurements in Secrets Manager

### DIFF
--- a/ci_template.yml
+++ b/ci_template.yml
@@ -155,6 +155,53 @@ Resources:
                 "aws:PrincipalArn": !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/*"
       SecretId: !Ref rSigningSecret
 
+  rMeasurementSecret:
+    Type: "AWS::SecretsManager::Secret"
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W77
+            reason: "Ignoring KMS"
+    Properties:
+      Description: !Sub "${AWS::StackName} Enclave Measurement Secret"
+
+  rMeasurementSecretPolicy:
+    Type: "AWS::SecretsManager::ResourcePolicy"
+    Properties:
+      BlockPublicPolicy: true
+      ResourcePolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: EnforceIdentityPerimeter
+            Effect: Deny
+            Principal:
+              AWS: "*"
+            Action: "secretsmanager:*"
+            Resource: "*"
+            Condition:
+              StringNotEqualsIfExists:
+                "aws:PrincipalAccount": !Ref "AWS::AccountId"
+              BoolIfExists:
+                "aws:PrincipalIsAWSService": "false"
+          - Sid: EnforceNetworkPerimeter
+            Effect: Deny
+            Principal:
+              AWS: "*"
+            Action: "secretsmanager:*"
+            Resource: "*"
+            Condition:
+              StringNotEqualsIfExists:
+                "aws:SourceVpc": !Ref "pVpcId"
+                "aws:PrincipalTag/network-perimeter-exception": "true"
+              BoolIfExists:
+                "aws:PrincipalIsAWSService": "false"
+                "aws:ViaAWSService": "false"
+              ArnNotLikeIfExists:
+                "aws:PrincipalArn": !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/*"
+      SecretId: !Ref rMeasurementSecret
+
   rArtifactBucket:
     Type: "AWS::S3::Bucket"
     UpdateReplacePolicy: Retain
@@ -861,6 +908,9 @@ Resources:
                 Action: "secretsmanager:GetSecretValue"
                 Resource: !Ref rSigningSecret
               - Effect: Allow
+                Action: "secretsmanager:PutSecretValue"
+                Resource: !Ref rMeasurementSecret
+              - Effect: Allow
                 Action: "signer:StartSigningJob"
                 Resource: !Ref rSigningProfile
               - Effect: Allow
@@ -1011,6 +1061,9 @@ Resources:
           - Name: PRIVATE_KEY
             Type: SECRETS_MANAGER
             Value: !Ref rSigningSecret
+          - Name: MEASUREMENT_SECRET_ID
+            Type: PLAINTEXT
+            Value: !Ref rMeasurementSecret
         Fleet: !If
           - cUseCodeBuildFleet
           - FleetArn: !Ref rCodeBuildFleet

--- a/ci_template.yml
+++ b/ci_template.yml
@@ -861,10 +861,6 @@ Resources:
                 Provider: StepFunctions
               Configuration:
                 StateMachineArn: !Ref rKeyPolicyStateMachine
-                InputType: FilePath
-                Input: measurements.json
-              InputArtifacts:
-                - Name: EnclaveBuildOutput
               OutputArtifacts:
                 - Name: KeyPolicyInvokeOutput
               RunOrder: 2
@@ -1180,6 +1176,9 @@ Resources:
                   - "kms:GetKeyPolicy"
                   - "kms:PutKeyPolicy"
                 Resource: !Ref pEncryptionKeyArn
+              - Effect: Allow
+                Action: "secretsmanager:GetSecretValue"
+                Resource: !Ref rMeasurementSecret
       Tags:
         - Key: "aws-cloudformation:stack-name"
           Value: !Ref "AWS::StackName"
@@ -1196,8 +1195,17 @@ Resources:
     Type: "AWS::StepFunctions::StateMachine"
     Properties:
       Definition:
-        StartAt: BuildCondition
+        StartAt: GetMeasurements
         States:
+          GetMeasurements:
+            Type: Task
+            Resource: "arn:aws:states:::aws-sdk:secretsmanager:getSecretValue"
+            Parameters:
+              SecretId: "${SecretId}"
+            ResultSelector:
+              "Measurements.$": "States.StringToJson($.SecretString)"
+            OutputPath: "$.Measurements"
+            Next: BuildCondition
           BuildCondition:
             Type: Pass
             InputPath: "$.Measurements"
@@ -1253,6 +1261,7 @@ Resources:
             End: true
       DefinitionSubstitutions:
         KeyArn: !Ref pEncryptionKeyArn
+        SecretId: !Ref rMeasurementSecret
       EncryptionConfiguration:
         Type: AWS_OWNED_KEY
       RoleArn: !GetAtt rStepFunctionsRole.Arn

--- a/enclave/buildspec.yml
+++ b/enclave/buildspec.yml
@@ -19,6 +19,7 @@ phases:
       - nitro-cli build-enclave --docker-uri "enclave-vault:latest" --output-file enclave-vault.eif --private-key nitro_vault_key.pem --signing-certificate nitro_vault_cert.pem > temp_measurements.json
       - PCR3=$(python -c"import hashlib; h=hashlib.sha384(); h.update(b'\0'*48); h.update(\"${INSTANCE_ROLE_ARN}\".encode('utf-8')); print(h.hexdigest())")
       - jq --arg PCR3 "$PCR3" '.Measurements += {"PCR3":$PCR3}' temp_measurements.json > measurements.json
+      - aws secretsmanager put-secret-value --secret-id "${MEASUREMENT_SECRET_ID}" --secret-string file://measurements.json
 
 artifacts:
   discard-paths: yes

--- a/enclave/buildspec.yml
+++ b/enclave/buildspec.yml
@@ -25,7 +25,6 @@ artifacts:
   discard-paths: yes
   files:
     - enclave/enclave-vault.eif  # Used by Deploy:DeployVault
-    - enclave/measurements.json  # Used by Invoke:UpdateKeyPolicyAttestations
     - vault_template.yml  # Used by Deploy:DeployVault
     - vault_template_configuration.json  # Used by Deploy:DeployVault
 


### PR DESCRIPTION
*Issue #, if available:* fixes #32

*Description of changes:*

Store the enclave measurements in AWS Secrets Manager instead of as an S3 build artifact


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
