### PR TITLE
[fix] Increase VPC canary timeout

### DIFF
--- a/canary/template.yml
+++ b/canary/template.yml
@@ -286,6 +286,7 @@ Resources:
             RoleArn: !GetAtt rEventBridgeSchedulerRole.Arn
             ScheduleExpression: "rate(1 minute)"
       Role: !GetAtt rCanaryVpcFunctionRole.Arn
+      Timeout: 2  # seconds
       VpcConfig:
         SecurityGroupIds:
           - !Ref rLambdaSecurityGroup
@@ -337,7 +338,7 @@ Resources:
       Period: 60  # seconds
       Statistic: Average
       Threshold: 0
-      TreatMissingData: notBreaching
+      TreatMissingData: breaching
       Unit: Count
 
   DecryptionNoVpcAlarm:
@@ -361,7 +362,7 @@ Resources:
       Period: 60  # seconds
       Statistic: Average
       Threshold: 0
-      TreatMissingData: notBreaching
+      TreatMissingData: breaching
       Unit: Count
 
   AlarmTopic:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The VPC canary was consistently timing out at 1 second


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
