### PR TITLE
fix: reproducible PCR0 using Kaniko, pinned base images, and determin…

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,7 +7,25 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - docker buildx bake
+      - export SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
+      # Build parent image with BuildKit
+      - docker buildx bake -f docker-bake.hcl --set default.targets=parent
+      # Build enclave image with Kaniko for reproducible PCR0
+      - mkdir -p /tmp/enclave-output
+      - >-
+        docker run --rm
+        -v $(pwd)/enclave:/workspace
+        -v /tmp/enclave-output:/output
+        gcr.io/kaniko-project/executor:v1.23.2
+        --dockerfile /workspace/Dockerfile
+        --context /workspace
+        --reproducible
+        --no-push
+        --tarPath=/output/enclave.tar
+        --destination=enclave-vault:latest
+        --build-arg TARGETPLATFORM=aarch64-unknown-linux-musl
+        --build-arg SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
+      - docker load -i /tmp/enclave-output/enclave.tar
       - echo Build completed on `date`
   post_build:
     commands:

--- a/enclave/Dockerfile
+++ b/enclave/Dockerfile
@@ -6,7 +6,7 @@
 ##
 ## based on https://github.com/aws/aws-nitro-enclaves-acm/blob/main/env/enclave/Dockerfile
 ####################################################################################################
-FROM public.ecr.aws/docker/library/rust:alpine AS kmstool
+FROM public.ecr.aws/docker/library/rust:alpine@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS kmstool
 
 ARG TARGETPLATFORM
 ARG SOURCE_DATE_EPOCH
@@ -181,25 +181,26 @@ COPY . .
 RUN cargo build --target $TARGETPLATFORM --release --color never
 
 ####################################################################################################
-## Final image
+## Runtime deps - install packages here so the final image only has COPY layers
 ####################################################################################################
-FROM public.ecr.aws/docker/library/alpine:latest AS runtime
-ARG TARGETPLATFORM
-ARG SOURCE_DATE_EPOCH
-
+FROM public.ecr.aws/docker/library/alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS runtime-deps
 RUN apk add --no-cache ca-certificates libgcc
-RUN addgroup -S vault && adduser -S vault -G vault
 
-WORKDIR /app
+####################################################################################################
+## Final image - ONLY deterministic COPY and ENV, no RUN commands
+####################################################################################################
+FROM public.ecr.aws/docker/library/alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS runtime
+ARG TARGETPLATFORM
+
+COPY --from=runtime-deps /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=runtime-deps /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
 
 # Copy our build
 COPY --from=builder /app/target/${TARGETPLATFORM}/release/enclave-vault /app/enclave-vault
 
-# Copy NSM library for attestation (only dynamic library needed - others are statically linked)
+# Copy NSM library for attestation
 COPY --from=kmstool /usr/lib/libnsm.so /usr/lib/libnsm.so
 
 ENV LD_LIBRARY_PATH="/usr/lib"
-
-RUN chmod +x /app/enclave-vault
 
 CMD ["/app/enclave-vault"]


### PR DESCRIPTION
  *Issue #, if available:* #289

  *Description of changes:*

  Enables reproducible PCR0 values when building the enclave image, so that anyone building from the same commit on the same architecture (ARM/Graviton) gets an identical Enclave Image File.

  Three changes:

  1. **Kaniko replaces BuildKit for the enclave image build** (`buildspec.yml`). Kaniko's `--reproducible` flag normalizes all Docker layer metadata (timestamps, file ownership, image config) that BuildKit
  leaves non-deterministic. The parent image still uses BuildKit since it doesn't need a reproducible PCR0.

  2. **Base images pinned by SHA256 digest** (`enclave/Dockerfile`). Ensures `rust:alpine` and `alpine` resolve to the exact same image regardless of when or where the build runs.

  3. **Final stage uses only COPY, no RUN** (`enclave/Dockerfile`). Commands like `apk add`, `adduser`, and `chmod` write non-deterministic metadata (timestamps in `/etc/shadow`, apk database files). A new
  `runtime-deps` stage installs packages, and the final stage selectively copies only the files needed (`ca-certificates.crt`, `libgcc_s.so.1`).

  Tested by running two independent CodeBuild jobs (ARM, `aws/codebuild/amazonlinux-aarch64-standard:3.0`, XLARGE) from the same commit. Both produced identical PCR0.

  Reference: [Establishing verifiable security: Reproducible builds and AWS Nitro Enclaves](https://aws.amazon.com/blogs/web3/establishing-verifiable-security-reproducible-builds-and-aws-nitro-enclaves/)

  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.