### PR TITLE
fix: hardcode SOURCE_DATE_EPOCH=0 for builds without git metadata

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,7 +7,8 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - export SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
+      # Fixed epoch ensures identical PCR0 regardless of source checkout method (git clone vs zip)
+      - export SOURCE_DATE_EPOCH=0
       # Build parent image with BuildKit
       - docker buildx bake -f docker-bake.hcl parent
       # Build enclave image with Kaniko for reproducible PCR0


### PR DESCRIPTION
*Description of changes:*
CodePipeline with CodeStarSourceConnection delivers source as a zip archive without .git directory. git log fails, leaving SOURCE_DATE_EPOCH empty, which causes mimalloc compilation to fail.

Hardcoding to 0 ensures consistent builds regardless of how source is checked out (git clone vs zip download).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
