### PR TITLE
fix(enclave): accept uppercase hex in hex_decode

### DIFF
--- a/enclave/src/expressions.rs
+++ b/enclave/src/expressions.rs
@@ -367,6 +367,28 @@ mod tests {
     }
 
     #[test]
+    fn test_hex_decode_accepts_uppercase() {
+        let expressions: HashMap<String, String> =
+            HashMap::from([("hex_decode".into(), "'426F6F'.hex_decode()".into())]);
+
+        let fields = HashMap::default();
+        let actual = execute_expressions(&fields, &expressions).unwrap();
+
+        assert_eq!(actual.get("hex_decode"), Some(&Value::String("Boo".into())));
+    }
+
+    #[test]
+    fn test_hex_decode_accepts_mixed_case() {
+        let expressions: HashMap<String, String> =
+            HashMap::from([("hex_decode".into(), "'426F62'.hex_decode()".into())]);
+
+        let fields = HashMap::default();
+        let actual = execute_expressions(&fields, &expressions).unwrap();
+
+        assert_eq!(actual.get("hex_decode"), Some(&Value::String("Bob".into())));
+    }
+
+    #[test]
     fn test_complex() {
         let expressions: HashMap<String, String> =
             HashMap::from([("age".into(), "date(birth_date).age()".into())]);

--- a/enclave/src/functions.rs
+++ b/enclave/src/functions.rs
@@ -4,7 +4,7 @@
 use aws_lc_rs::digest;
 use cel_interpreter::{FunctionContext, ResolveResult, extractors::This};
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveTime, TimeZone, Utc};
-use data_encoding::{BASE64, HEXLOWER};
+use data_encoding::{BASE64, HEXLOWER, HEXLOWER_PERMISSIVE};
 use std::sync::Arc;
 
 // Default functions available:
@@ -48,7 +48,7 @@ pub fn hex_encode(This(this): This<Arc<String>>) -> String {
 }
 
 pub fn hex_decode(ftx: &FunctionContext, This(this): This<Arc<String>>) -> ResolveResult {
-    match HEXLOWER.decode(this.as_bytes()) {
+    match HEXLOWER_PERMISSIVE.decode(this.as_bytes()) {
         Ok(val) => match String::from_utf8(val) {
             Ok(result) => Ok(result.into()),
             Err(e) => ftx.error(e.to_string()).into(),


### PR DESCRIPTION
Background: detailed bug report (closed) on the author's fork: https://github.com/jplock/sample-code-for-a-secure-vault-using-aws-nitro-enclaves/issues/3
Originally landed on the fork as https://github.com/jplock/sample-code-for-a-secure-vault-using-aws-nitro-enclaves/pull/10.

## Root cause

`hex_decode` in `enclave/src/functions.rs` was migrated from the `hex` crate (case-insensitive per RFC 4648 §8) to `data_encoding::HEXLOWER`, which strictly rejects uppercase hex characters. This regressed callers passing uppercase or mixed-case hex strings.

## Fix

Switch `hex_decode` to `data_encoding::HEXLOWER_PERMISSIVE`, which is case-insensitive on decode and restores the prior `hex` crate behavior. `hex_encode` and the SHA hash helpers continue to use `HEXLOWER` so emitted strings remain lowercase by convention.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test -p enclave-vault`
- [x] Added `test_hex_decode_accepts_uppercase` (decodes `'426F6F'` → `"Boo"`)
- [x] Added `test_hex_decode_accepts_mixed_case` (decodes `'426F62'` → `"Bob"`)