### PR TITLE
fix(parent): IAM role defaults to None instead of literal "None"

### DIFF
--- a/parent/src/configuration.rs
+++ b/parent/src/configuration.rs
@@ -48,7 +48,7 @@ pub struct ParentOptions {
     /// Optional IAM role name for credential assumption.
     ///
     /// If not specified, the instance's default IAM role is used.
-    #[arg(long, default_value = "None", env("PARENT_ROLE_NAME"))]
+    #[arg(long, env("PARENT_ROLE_NAME"))]
     pub role: Option<String>,
 
     /// Skip the background enclave refresh loop.
@@ -104,6 +104,17 @@ mod tests {
         let opts = ParentOptions::try_parse_from(["test"]).unwrap();
         assert_eq!(opts.host, "127.0.0.1");
         assert_eq!(opts.port, 8080);
+        assert!(opts.role.is_none());
+    }
+
+    #[test]
+    fn test_parse_role_defaults_to_none() {
+        assert!(
+            ParentOptions::try_parse_from(["test"])
+                .unwrap()
+                .role
+                .is_none()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Background: detailed bug report (closed) on the author's fork: https://github.com/jplock/sample-code-for-a-secure-vault-using-aws-nitro-enclaves/issues/4
Originally landed on the fork as https://github.com/jplock/sample-code-for-a-secure-vault-using-aws-nitro-enclaves/pull/8.

## Root cause

`parent/src/configuration.rs` declared `#[arg(long, default_value = "None", env("PARENT_ROLE_NAME"))]` on the `role: Option<String>` field. Clap's `default_value` accepts a string literal that it parses through `FromStr`, so the unset case produced `Some("None")` rather than the Rust `None` variant. This contradicted the documented default and the `Default` impl, and broke IMDS credential lookup by treating the literal string `"None"` as a valid IAM role name.

## Fix

Removed `default_value = "None"`. Clap automatically defaults `Option<T>` fields to `None` when neither the CLI arg nor the `PARENT_ROLE_NAME` env var is set. The env-var binding is preserved.

## Test plan

- [x] Added `test_parse_role_defaults_to_none` asserting `role.is_none()` with no args
- [x] Extended `test_parse_with_defaults` to assert `role.is_none()`
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test -p parent-vault --verbose` (100 unit + 8 integration tests pass)