### PR TITLE
fix(parent): re-query enclaves after launch to avoid stale list

### DIFF
--- a/parent/src/enclaves.rs
+++ b/parent/src/enclaves.rs
@@ -70,26 +70,12 @@ impl Enclaves {
         enclaves.clone()
     }
 
-    /// Refreshes the enclave list and optionally launches new enclaves.
-    ///
-    /// This method:
-    /// 1. Calls `nitro-cli describe-enclaves` to get current enclaves
-    /// 2. Launches new enclaves if needed (unless `skip_run_enclaves` is true)
-    /// 3. Filters and stores only enclaves matching [`ENCLAVE_PREFIX`]
-    ///
-    /// # Arguments
-    ///
-    /// * `skip_run_enclaves` - If true, don't launch new enclaves
+    /// Queries `nitro-cli describe-enclaves` and parses the result.
     ///
     /// # Errors
     ///
-    /// Returns an error if:
-    /// - `nitro-cli` command fails
-    /// - JSON parsing of output fails
-    /// - Launching new enclaves fails
-    #[tracing::instrument(skip(self))]
-    pub async fn refresh(&self, skip_run_enclaves: bool) -> Result<(), AppError> {
-        // Get current enclave list from nitro-cli
+    /// Returns an error if `nitro-cli` exits non-zero or the JSON output fails to parse.
+    async fn describe_enclaves(&self) -> Result<Vec<EnclaveDescribeInfo>, AppError> {
         let output = Command::new("nitro-cli")
             .arg("describe-enclaves")
             .output()
@@ -106,6 +92,35 @@ impl Enclaves {
 
         tracing::trace!("[parent] enclaves: {:?}", enclaves);
 
+        Ok(enclaves)
+    }
+
+    /// Refreshes the enclave list and optionally launches new enclaves.
+    ///
+    /// This method:
+    /// 1. Calls `nitro-cli describe-enclaves` to get current enclaves
+    /// 2. Launches new enclaves if needed (unless `skip_run_enclaves` is true)
+    /// 3. Re-queries `nitro-cli describe-enclaves` after launching so freshly
+    ///    launched enclaves are immediately visible (otherwise the stored list
+    ///    reflects the pre-launch state and replacement enclaves are invisible
+    ///    until the next refresh tick)
+    /// 4. Filters and stores only enclaves matching [`ENCLAVE_PREFIX`]
+    ///
+    /// # Arguments
+    ///
+    /// * `skip_run_enclaves` - If true, don't launch new enclaves
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - `nitro-cli` command fails
+    /// - JSON parsing of output fails
+    /// - Launching new enclaves fails
+    #[tracing::instrument(skip(self))]
+    pub async fn refresh(&self, skip_run_enclaves: bool) -> Result<(), AppError> {
+        // Get current enclave list from nitro-cli
+        let mut enclaves = self.describe_enclaves().await?;
+
         // Launch additional enclaves if needed
         if !skip_run_enclaves {
             let delta = MAX_ENCLAVES_PER_INSTANCE - enclaves.len();
@@ -114,6 +129,8 @@ impl Enclaves {
                 for _ in 0..delta {
                     self.run_enclave().await?;
                 }
+                // Re-query so freshly launched enclaves are reflected in the stored list.
+                enclaves = self.describe_enclaves().await?;
             }
         } else {
             tracing::warn!("[parent] skipping launching enclaves");


### PR DESCRIPTION
Background: detailed bug report (closed) on the author's fork: https://github.com/jplock/sample-code-for-a-secure-vault-using-aws-nitro-enclaves/issues/5
Originally landed on the fork as https://github.com/jplock/sample-code-for-a-secure-vault-using-aws-nitro-enclaves/pull/7.

## Root cause

`Enclaves::refresh()` captured the enclave list from `nitro-cli describe-enclaves` before launching any replacement enclaves, then wrote that pre-launch snapshot into the internal `RwLock<Vec<_>>`. When all enclaves crashed simultaneously, the freshly launched replacements were not present in the stored list, so requests returned 404/500 for up to 10 seconds until the next refresh tick.

## Fix

After the `for _ in 0..delta { self.run_enclave().await?; }` loop in `refresh()`, re-query `nitro-cli describe-enclaves` and use the post-launch result for the filter-and-store step. Extracted the describe call into a small private `describe_enclaves()` helper so both call sites share the same error handling and tracing.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test -p parent-vault --verbose` (99 unit + 8 integration tests pass)
- [ ] Manual verification on Nitro-enabled EC2: kill all enclaves, confirm `/enclaves` reports the replacements within one refresh tick