### PR TITLE
fix(parent): set vsock read/write timeouts to prevent indefinite hangs

### DIFF
--- a/parent/src/enclaves.rs
+++ b/parent/src/enclaves.rs
@@ -23,6 +23,8 @@
 //! [`ENCLAVE_PREFIX`]: crate::constants::ENCLAVE_PREFIX
 //! [`MAX_ENCLAVES_PER_INSTANCE`]: crate::constants::MAX_ENCLAVES_PER_INSTANCE
 
+use std::time::Duration;
+
 use serde_json::json;
 use tokio::{process::Command, sync::RwLock};
 use vsock::{VsockAddr, VsockStream};
@@ -37,6 +39,15 @@ use crate::{
     models::EnclaveResponse,
     protocol::{recv_message, send_message},
 };
+
+/// Read/write timeout applied to every [`VsockStream`] used to talk to an enclave.
+///
+/// `tokio::task::spawn_blocking` threads cannot be aborted, so the surrounding HTTP request
+/// timeout cannot unblock a vsock read that is stuck on a slow KMS call or a misbehaving vsock
+/// proxy. Setting an explicit socket-level timeout ensures the blocking thread is released and
+/// the error propagates back to the caller. The value is intentionally chosen below the HTTP
+/// request timeout so vsock failures surface first; tune as needed.
+const VSOCK_IO_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Manager for Nitro Enclaves.
 ///
@@ -196,6 +207,10 @@ impl Enclaves {
     ) -> Result<EnclaveResponse, AppError> {
         // Connect to enclave via vsock
         let mut stream = VsockStream::connect(&VsockAddr::new(cid, port))?;
+
+        // Bound blocking I/O so a stuck KMS call or vsock proxy can't pin this thread forever.
+        stream.set_read_timeout(Some(VSOCK_IO_TIMEOUT))?;
+        stream.set_write_timeout(Some(VSOCK_IO_TIMEOUT))?;
 
         tracing::debug!("[parent] connected to CID {} and port {}", cid, port);
 


### PR DESCRIPTION
Background: detailed bug report (closed) on the author's fork: https://github.com/jplock/sample-code-for-a-secure-vault-using-aws-nitro-enclaves/issues/6
Originally landed on the fork as https://github.com/jplock/sample-code-for-a-secure-vault-using-aws-nitro-enclaves/pull/9.

## Root cause

`Enclaves::decrypt()` opened a `VsockStream` without configuring read or write timeouts. The function runs on a `tokio::task::spawn_blocking` worker, and blocking threads cannot be aborted from the async runtime. As a result, a slow KMS call or a stalled vsock proxy left the blocking `read`/`write` parked indefinitely. The surrounding HTTP request timeout fired, but the underlying thread stayed pinned, exhausting the blocking pool and forcing an enclave restart to recover.

## Fix

After `VsockStream::connect`, call `set_read_timeout`/`set_write_timeout` with a 20-second `VSOCK_IO_TIMEOUT` constant. Errors propagate through the existing `From<std::io::Error> for AppError` impl via `?`. The timeout is intentionally below the HTTP request timeout so vsock failures surface first; it can be tuned by adjusting the constant.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test -p parent-vault --verbose` (99 unit + 8 integration tests pass)
- [ ] Verify on EC2 with Nitro Enclaves that a stalled KMS dependency returns an error within ~20s instead of hanging the blocking thread